### PR TITLE
upgrade circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val plugin = project("sbt-paradox-material-theme", file("plugin"))
     publishLocal := publishLocal.dependsOn(theme / publishLocal).value,
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.2"),
     libraryDependencies += "org.jsoup" % "jsoup" % "1.10.3",
-    libraryDependencies += "io.circe" %% "circe-core" % "0.8.0",
+    libraryDependencies += "io.circe" %% "circe-core" % "0.9.3",
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "paradox-material-theme.properties"
       IO.write(file, s"version=${version.value}")


### PR DESCRIPTION
circe 0.8.0 is from May 2017, and when this plugin is enabled, but
another plugin brings in a higher circe version, sbt fails with the
following:

```
(docsGen / Compile / paradoxMaterialTheme / mappings) java.lang.NoSuchMethodError: io.circe.Encoder$.encodeTraversableOnce(Lio/circe/Encoder;Lscala/collection/generic/IsTraversableOnce;)Lio/circe/ArrayEncoder;
```

I know that the plugin doesn't actually use `encodeTraversableOnce`
directly, but simply upgrading circe fixed the above.